### PR TITLE
Fixed deprecated filter syntax and update pg user task.

### DIFF
--- a/bare/roles/init/tasks/main.yml
+++ b/bare/roles/init/tasks/main.yml
@@ -17,10 +17,10 @@
 
 - name: Bootstrap Python on Amazon Linux
   raw: yum update && yum install -y python27
-  when: python_installed|failed and yum_installed|succeeded
+  when: python_installed is failed and yum_installed is succeeded
   become: yes
 
 - name: Bootstrap Python on Ubuntu Linux
   raw: apt update && apt install -y python
-  when: python_installed|failed and apt_installed|succeeded
+  when: python_installed is failed and apt_installed is succeeded
   become: yes

--- a/bare/roles/postgres/tasks/database.yml
+++ b/bare/roles/postgres/tasks/database.yml
@@ -34,13 +34,14 @@
     name: "{{ mastodon_db }}"
     login_unix_socket: "{{ mastodon_db_login_unix_socket }}"
   register: create_local_db
-  when: create_remote_db|skipped
+  when: create_remote_db is skipped
 
 - name: Create database user {{ mastodon_db_user }}
   postgresql_user:
     db: "{{ mastodon_db }}"
     name: "{{ mastodon_db_user }}"
     password: "{{ mastodon_db_password }}"
+    encrypted: true
     login_unix_socket: "{{ mastodon_db_login_unix_socket }}"
     role_attr_flags: CREATEDB
-  when: create_remote_db_user|skipped
+  when: create_remote_db_user is skipped

--- a/bare/roles/web/tasks/ruby.yml
+++ b/bare/roles/web/tasks/ruby.yml
@@ -32,7 +32,7 @@
   command: make
   args:
     chdir: "{{ rbenv_home }}/src"
-  when: rbenv_configure|succeeded
+  when: rbenv_configure is succeeded
 
 - name: Update profile settings
   copy:
@@ -54,7 +54,7 @@
   shell: "{{ rbenv_home }}/bin/rbenv install {{ ruby_version }}"
   args:
     executable: /bin/bash
-  when: ruby_installed|failed
+  when: ruby_installed is failed
 
 - name: Set the default Ruby version to {{ ruby_version }}
   shell: "{{ rbenv_home }}/bin/rbenv global {{ ruby_version }}"
@@ -67,4 +67,4 @@
     executable: "{{ rbenv_home }}/shims/gem"
     state: latest
     user_install: false
-  when: default_ruby_version|succeeded
+  when: default_ruby_version is succeeded

--- a/docker/roles/core/tasks/main.yml
+++ b/docker/roles/core/tasks/main.yml
@@ -44,5 +44,5 @@
 
 - name: Create main docker network
   raw: "docker network create -d bridge {{ mastodon_docker_network }}"
-  when: docker_network|failed
+  when: docker_network is failed
   become: yes

--- a/docker/roles/init/tasks/main.yml
+++ b/docker/roles/init/tasks/main.yml
@@ -17,10 +17,10 @@
 
 - name: Bootstrap Python on Amazon Linux
   raw: yum update && yum install -y python27
-  when: python_installed|failed and yum_installed|succeeded
+  when: python_installed is failed and yum_installed is succeeded
   become: yes
 
 - name: Bootstrap Python on Ubuntu Linux
   raw: apt update && apt install -y python
-  when: python_installed|failed and apt_installed|succeeded
+  when: python_installed is failed and apt_installed is succeeded
   become: yes


### PR DESCRIPTION
Ansible's deprecation warning on version 2.5.2:

    [DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|skipped`
    instead use `result is skipped`. This feature will be removed in version 2.9. Deprecation
    warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

PG user module requires encryption be explicitly enabled now otherwise task will fail.