### PR TITLE
Updated to work with mastodon 2.6.1

### DIFF
--- a/bare/roles/web/files/nginx/letsencrypt.conf.j2
+++ b/bare/roles/web/files/nginx/letsencrypt.conf.j2
@@ -2,7 +2,7 @@
 server {
   listen 80;
   listen [::]:80;
-  server_name {{ mastodon_host }}
+  server_name {{ mastodon_host }};
   root {{ mastodon_home }}/{{ mastodon_path }}/public;
   location /.well-known/acme-challenge/ { allow all; }
 }

--- a/bare/roles/web/files/nginx/mastodon.conf.j2
+++ b/bare/roles/web/files/nginx/mastodon.conf.j2
@@ -6,10 +6,12 @@ map $http_upgrade $connection_upgrade {
 server {
   listen 80;
   listen [::]:80;
-  server_name {{ mastodon_host }}
-  root {{ mastodon_home }}/{{ mastodon_path }}/public;
+  server_name {{ mastodon_host }};
+
   # Useful for Let's Encrypt
-  location /.well-known/acme-challenge/ { allow all; }
+  location /.well-known/acme-challenge/ { 
+    alias {{ mastodon_home }}/{{ mastodon_path }}/public/.well-known/acme-challenge/;
+  }
   location / { return 301 https://$host$request_uri; }
 }
 

--- a/bare/vars/common.yml
+++ b/bare/vars/common.yml
@@ -1,6 +1,6 @@
-ruby_version: 2.5.1
+ruby_version: 2.5.3
 rbenv_version: v1.1.1
-ruby_build_version: v20180424
+ruby_build_version: v20181019
 os_family: "{{ ansible_os_family|lower }}"
 mastodon_user: "mastodon"
 mastodon_home: "/home/{{ mastodon_user }}"

--- a/spec/debian/debian_spec.rb
+++ b/spec/debian/debian_spec.rb
@@ -20,7 +20,7 @@ describe 'Ansible Debian target' do
     end
 
     describe command('ruby -v') do
-      its(:stdout) { should match(/2\.5\.1/) }
+      its(:stdout) { should match(/2\.5\.3/) }
     end
 
     describe file('/usr/bin/nodejs') do
@@ -71,7 +71,7 @@ describe 'Ansible Debian target' do
     end
 
     describe command('ruby-build --version') do
-      its(:stdout) { should match(/ruby-build 20180424/) }
+      its(:stdout) { should match(/ruby-build 20181019/) }
     end
 
     describe file('/home/mastodon/live') do


### PR DESCRIPTION
Mastodon 2.6.1 now uses a new ruby version. I also fixed a small issue with the letsencrypt certificate stuff. Now renewing the certificate also works 😉 .