### PR TITLE
Uses mastodon_home var to determine where bundle is located.

### DIFF
--- a/bare/roles/web/files/systemd/mastodon-sidekiq.service.j2
+++ b/bare/roles/web/files/systemd/mastodon-sidekiq.service.j2
@@ -8,7 +8,7 @@ User=mastodon
 WorkingDirectory={{ mastodon_home }}/{{ mastodon_path }}
 Environment="RAILS_ENV=production"
 Environment="DB_POOL=5"
-ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 5 -q default -q push -q mailers -q pull
+ExecStart={{ mastodon_home }}/.rbenv/shims/bundle exec sidekiq -c 5 -q default -q push -q mailers -q pull
 TimeoutSec=15
 Restart=always
 


### PR DESCRIPTION
Just like the mastodon-web.service, we should not hardcode
/home/mastodon/ as this can be changed by variables to other places.