### PR TITLE
Update node version from 8.x to 10.x

### DIFF
--- a/bare/roles/web/tasks/repositories.yml
+++ b/bare/roles/web/tasks/repositories.yml
@@ -19,4 +19,4 @@
   become: yes
   with_items:
     - repo: "deb https://dl.yarnpkg.com/debian/ stable main"
-    - repo: "deb https://deb.nodesource.com/node_8.x {{ ubuntu_codename }} main"
+    - repo: "deb https://deb.nodesource.com/node_10.x {{ ubuntu_codename }} main"


### PR DESCRIPTION
I ran into the following error when applying the bare directory playbook.
```
TASK [web : Yarn install] ***********************************************************************************************************
fatal: [my-remote-host]: FAILED! => {"changed": true, "cmd": ["yarn", "install", "--pure-lockfile"], "delta": "0:00:00.480367", "end": "2020-02-19 15:21:36.724338", "msg": "non-zero return code", "rc": 1, "start": "2020-02-19 15:21:36.243971", "stderr": "error @tootsuite/mastodon@: The engine \"node\" is incompatible with this module. Expected version \">=10.13 <13\". Got \"8.17.0\"\nerror Found incompatible module.", "stderr_lines": ["error @tootsuite/mastodon@: The engine \"node\" is incompatible with this module. Expected version \">=10.13 <13\". Got \"8.17.0\"", "error Found incompatible module."], "stdout": "yarn install v1.21.1\n[1/6] Validating package.json...\ninfo Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.", "stdout_lines": ["yarn install v1.21.1", "[1/6] Validating package.json...", "info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command."]}
	to retry, use: --limit @/Users/xxxx/mastodon-ansible/bare/playbook.retry
```

I checked it on the server.

```
my-remote-host:/home/mastodon/live$ yarn install --pure-lockfile
yarn install v1.21.1
[1/6] Validating package.json...
error @tootsuite/mastodon@: The engine "node" is incompatible with this module. Expected version ">=10.13 <13". Got "8.17.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Therefore, the version of node was updated from 8.x to 10.x.
```
my-remote-host:$ node -v
v10.19.0
```

Please check.