### PR TITLE
Remove libgdbm5 from debian dependencies...

### DIFF
--- a/bare/vars/common.yml
+++ b/bare/vars/common.yml
@@ -1,6 +1,6 @@
-ruby_version: 2.6.5
+ruby_version: 2.6.6
 rbenv_version: v1.1.1
-ruby_build_version: v20191004
+ruby_build_version: v20200401
 os_family: "{{ ansible_os_family|lower }}"
 mastodon_user: "mastodon"
 mastodon_home: "/home/{{ mastodon_user }}"

--- a/bare/vars/debian_vars.yml
+++ b/bare/vars/debian_vars.yml
@@ -15,7 +15,6 @@ packages:
   - package: "imagemagick"
   - package: "libffi-dev"
   - package: "libgdbm-dev"
-  - package: "libgdbm5"
   - package: "libicu-dev"
   - package: "libidn11-dev"
   - package: "libncurses5-dev"

--- a/spec/debian/debian_spec.rb
+++ b/spec/debian/debian_spec.rb
@@ -20,7 +20,7 @@ describe 'Ansible Debian target' do
     end
 
     describe command('ruby -v') do
-      its(:stdout) { should match(/2\.6\.5/) }
+      its(:stdout) { should match(/2\.6\.6/) }
     end
 
     describe file('/usr/bin/nodejs') do
@@ -71,7 +71,7 @@ describe 'Ansible Debian target' do
     end
 
     describe command('ruby-build --version') do
-      its(:stdout) { should match(/ruby-build 20191004/) }
+      its(:stdout) { should match(/ruby-build 20200401/) }
     end
 
     describe file('/home/mastodon/live') do


### PR DESCRIPTION
...because Debian buster packages libgdbm6 and libgdbm-dev depends
on the correct version for the respective distro anyways.