### PR TITLE
Bump ruby to 2.6.6.

### DIFF
--- a/bare/vars/common.yml
+++ b/bare/vars/common.yml
@@ -1,6 +1,6 @@
 ruby_version: 2.6.6
 rbenv_version: v1.1.1
-ruby_build_version: v20191004
+ruby_build_version: v20200401
 os_family: "{{ ansible_os_family|lower }}"
 mastodon_user: "mastodon"
 mastodon_home: "/home/{{ mastodon_user }}"

--- a/bare/vars/common.yml
+++ b/bare/vars/common.yml
@@ -1,4 +1,4 @@
-ruby_version: 2.6.5
+ruby_version: 2.6.6
 rbenv_version: v1.1.1
 ruby_build_version: v20191004
 os_family: "{{ ansible_os_family|lower }}"

--- a/spec/debian/debian_spec.rb
+++ b/spec/debian/debian_spec.rb
@@ -71,7 +71,7 @@ describe 'Ansible Debian target' do
     end
 
     describe command('ruby-build --version') do
-      its(:stdout) { should match(/ruby-build 20191004/) }
+      its(:stdout) { should match(/ruby-build 20200401/) }
     end
 
     describe file('/home/mastodon/live') do

--- a/spec/debian/debian_spec.rb
+++ b/spec/debian/debian_spec.rb
@@ -20,7 +20,7 @@ describe 'Ansible Debian target' do
     end
 
     describe command('ruby -v') do
-      its(:stdout) { should match(/2\.6\.5/) }
+      its(:stdout) { should match(/2\.6\.6/) }
     end
 
     describe file('/usr/bin/nodejs') do


### PR DESCRIPTION
Mastodon v3.1.3 seems to require ruby 2.6.6.

(https://circleci.com/gh/tootsuite/mastodon-ansible/115)